### PR TITLE
Gets the app working, possibly in a hacky way.

### DIFF
--- a/src/main/java/com/example/dsl/OktaConfigurer.java
+++ b/src/main/java/com/example/dsl/OktaConfigurer.java
@@ -41,6 +41,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.channel.ChannelProcessingFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import com.example.dsl.overrides.SAMLDslEntryPoint;
 
 import java.io.File;
 import java.io.IOException;
@@ -93,7 +94,10 @@ public class OktaConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
     }
 
     private SAMLEntryPoint samlEntryPoint(WebSSOProfileOptions webSSOProfileOptions, CachingMetadataManager cachingMetadataManager, WebSSOProfile webSSOProfile, SAMLDefaultLogger samlLogger, SAMLContextProvider contextProvider) {
-        SAMLEntryPoint samlEntryPoint = samlEntryPoint(webSSOProfileOptions, webSSOProfile, contextProvider, cachingMetadataManager);
+        SAMLEntryPoint samlEntryPoint = new SAMLDslEntryPoint();
+        samlEntryPoint.setDefaultProfileOptions(webSSOProfileOptions);
+        samlEntryPoint.setWebSSOprofile(webSSOProfile);
+        samlEntryPoint.setContextProvider(contextProvider);
         samlEntryPoint.setMetadata(cachingMetadataManager);
         samlEntryPoint.setSamlLogger(samlLogger);
         return samlEntryPoint;
@@ -167,16 +171,6 @@ public class OktaConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFil
 
     private HTTPRedirectDeflateBinding httpRedirectDeflateBinding(ParserPool parserPool) {
         return new HTTPRedirectDeflateBinding(parserPool);
-    }
-
-    private SAMLEntryPoint samlEntryPoint(WebSSOProfileOptions webSSOProfileOptions, WebSSOProfile webSSOProfile, SAMLContextProvider contextProvider, MetadataManager cachingMetadataManager) {
-        SAMLEntryPoint samlEntryPoint = new SAMLEntryPoint();
-        samlEntryPoint.setDefaultProfileOptions(webSSOProfileOptions);
-
-        samlEntryPoint.setWebSSOprofile(webSSOProfile);
-        samlEntryPoint.setContextProvider(contextProvider);
-        samlEntryPoint.setMetadata(cachingMetadataManager);
-        return samlEntryPoint;
     }
 
     private SAMLProcessingFilter samlWebSSOProcessingFilter(SAMLAuthenticationProvider samlAuthenticationProvider, SAMLContextProvider contextProvider, SAMLProcessor samlProcessor) throws Exception {

--- a/src/main/java/com/example/dsl/overrides/SAMLDslEntryPoint.java
+++ b/src/main/java/com/example/dsl/overrides/SAMLDslEntryPoint.java
@@ -1,0 +1,65 @@
+package com.example.dsl.overrides;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.saml.context.SAMLContextProvider;
+import org.springframework.security.saml.log.SAMLLogger;
+import org.springframework.security.saml.metadata.MetadataManager;
+import org.springframework.security.saml.websso.WebSSOProfile;
+
+public class SAMLDslEntryPoint extends org.springframework.security.saml.SAMLEntryPoint{
+    /**
+     * Metadata manager, cannot be null, must be set.
+     * It is set directly in the custom config, so can be optional here.
+     * User could override it if desired.
+     *
+     * @param metadata manager
+     */
+    @Autowired(required = false)
+    @Override
+    public void setMetadata(MetadataManager metadata) {
+        super.setMetadata(metadata);
+    }
+
+
+    /**
+     * Logger for SAML events, cannot be null, must be set.
+     *
+     * @param samlLogger logger
+     * It is set in the custom config, so can be optional here.
+     * User could override it if desired.
+     */
+    @Autowired(required = false)
+    @Override
+    public void setSamlLogger(SAMLLogger samlLogger) {
+        super.setSamlLogger(samlLogger);
+    }
+
+    /**
+     * Profile for consumption of processed messages, cannot be null, must be set.
+     * It is set in the custom config, so can be optional here.
+     * User could override it if desired.
+     *
+     * @param webSSOprofile profile
+     */
+    @Autowired(required = false)
+    @Qualifier("webSSOprofile")
+    @Override
+    public void setWebSSOprofile(WebSSOProfile webSSOprofile) {
+        super.setWebSSOprofile(webSSOprofile);
+    }
+
+    /**
+     * Sets entity responsible for populating local entity context data.
+     * It is set in the custom config, so can be optional here.
+     * User could override it if desired.
+     *
+     * @param contextProvider provider implementation
+     */
+    @Autowired(required = false)
+    @Override
+    public void setContextProvider(SAMLContextProvider contextProvider) {
+        super.setContextProvider(contextProvider);
+    }
+
+}


### PR DESCRIPTION
Hey Jean, I think we should probably ask Rob Winch for some advice on this one, unless you have a better idea. I got this working in a fairly simple, easy manner, but I'm not sure if it's the best way. I had to override a class to do it. All of its functionality remains delegated to the superclass, but it still seems off to me. 

Take a look, it definitely works for me now.

-Implements SAMLDslEntryPoint, which extends SAMLEntryPoint, overriding four field initializations to not be required. They are called manually in this configuration, so there is no need to require spring to populate them. Hoping there is a better solution, but this works.
-Also consolidates the two SAMLEntryPoint methods in OktaConfigurer.
